### PR TITLE
Add Velog scraping pipeline

### DIFF
--- a/llm_engineering/__init__.py
+++ b/llm_engineering/__init__.py
@@ -1,4 +1,4 @@
 from llm_engineering import application, domain, infrastructure
 from llm_engineering.settings import settings
 
-__all__ = ["settings", "application", "domain", "infrastructure"]
+__all__ = ["application", "domain", "infrastructure", "settings"]

--- a/llm_engineering/application/crawlers/github.py
+++ b/llm_engineering/application/crawlers/github.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from pathlib import Path
 
 from loguru import logger
 
@@ -34,7 +35,7 @@ class GithubCrawler(BaseCrawler):
             os.chdir(local_temp)
             subprocess.run(["git", "clone", link])
 
-            repo_path = os.path.join(local_temp, os.listdir(local_temp)[0])  # noqa: PTH118
+            repo_path = str(next(Path(local_temp).iterdir()))
 
             tree = {}
             for root, _, files in os.walk(repo_path):

--- a/llm_engineering/application/networks/__init__.py
+++ b/llm_engineering/application/networks/__init__.py
@@ -1,3 +1,3 @@
 from .embeddings import CrossEncoderModelSingleton, EmbeddingModelSingleton
 
-__all__ = ["EmbeddingModelSingleton", "CrossEncoderModelSingleton"]
+__all__ = ["CrossEncoderModelSingleton", "EmbeddingModelSingleton"]

--- a/llm_engineering/application/preprocessing/__init__.py
+++ b/llm_engineering/application/preprocessing/__init__.py
@@ -1,3 +1,3 @@
 from .dispatchers import ChunkingDispatcher, CleaningDispatcher, EmbeddingDispatcher
 
-__all__ = ["CleaningDispatcher", "ChunkingDispatcher", "EmbeddingDispatcher"]
+__all__ = ["ChunkingDispatcher", "CleaningDispatcher", "EmbeddingDispatcher"]

--- a/llm_engineering/application/velog/__init__.py
+++ b/llm_engineering/application/velog/__init__.py
@@ -1,0 +1,3 @@
+from .service import VelogService
+
+__all__ = ["VelogService"]

--- a/llm_engineering/application/velog/constants.py
+++ b/llm_engineering/application/velog/constants.py
@@ -1,0 +1,31 @@
+V3_URL = "https://v3.velog.io/graphql"
+V2_URL = "https://v2.velog.io/graphql"
+
+POSTS_QUERY = """
+query velogPosts($input: GetPostsInput!) {
+    posts(input: $input) {
+        id
+        title
+        short_description
+        thumbnail
+        url_slug
+        released_at
+        updated_at
+    }
+}
+""".strip()
+
+GET_POST_QUERY = """
+query GetPost($id: ID) {
+    post(id: $id) {
+        id
+        title
+        body
+        short_description
+        thumbnail
+        url_slug
+        released_at
+        updated_at
+    }
+}
+""".strip()

--- a/llm_engineering/application/velog/service.py
+++ b/llm_engineering/application/velog/service.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import requests
+from loguru import logger
+
+from .constants import GET_POST_QUERY, POSTS_QUERY, V2_URL, V3_URL
+
+
+class VelogService:
+    """Simple client for the Velog GraphQL API."""
+
+    def __init__(self, access_token: str, refresh_token: str) -> None:
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+
+    def _headers(self) -> dict[str, str]:
+        if not self.access_token or not self.refresh_token:
+            raise ValueError("Velog tokens are missing")
+
+        return {
+            "origin": "https://velog.io",
+            "content-type": "application/json",
+            "cookie": f"access_token={self.access_token}; refresh_token={self.refresh_token}",
+        }
+
+    def _execute_query(
+        self, url: str, query: str, variables: Optional[dict[str, Any]] = None, operation_name: str | None = None
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"query": query}
+        if variables:
+            payload["variables"] = variables
+        if operation_name:
+            payload["operationName"] = operation_name
+
+        response = requests.post(url, json=payload, headers=self._headers(), timeout=10)
+        response.raise_for_status()
+        result = response.json()
+        return result.get("data", {})
+
+    def get_posts(self, username: str, cursor: str = "", limit: int = 50) -> list[dict[str, Any]]:
+        variables = {"input": {"username": username, "cursor": cursor, "limit": limit}}
+        data = self._execute_query(V3_URL, POSTS_QUERY, variables)
+        return data.get("posts", [])
+
+    def get_post(self, post_id: str) -> dict[str, Any]:
+        variables = {"id": post_id}
+        data = self._execute_query(V2_URL, GET_POST_QUERY, variables)
+        return data.get("post", {})
+
+    def get_all_posts(self, username: str) -> list[dict[str, Any]]:
+        cursor = ""
+        posts: list[dict[str, Any]] = []
+        while True:
+            batch = self.get_posts(username=username, cursor=cursor)
+            if not batch:
+                break
+            posts.extend(batch)
+            cursor = batch[-1]["id"]
+
+        detailed_posts = []
+        for post in posts:
+            try:
+                detailed = self.get_post(post["id"])
+            except Exception as exc:
+                logger.error(f"Failed to fetch post details: {exc!s}")
+                detailed = post
+            detailed_posts.append(detailed)
+        return detailed_posts

--- a/llm_engineering/domain/__init__.py
+++ b/llm_engineering/domain/__init__.py
@@ -9,6 +9,6 @@ __all__ = [
     "embedded_chunks",
     "exceptions",
     "inference",
-    "types",
     "prompt",
+    "types",
 ]

--- a/llm_engineering/model/inference/__init__.py
+++ b/llm_engineering/model/inference/__init__.py
@@ -1,4 +1,4 @@
 from .inference import LLMInferenceSagemakerEndpoint
 from .run import InferenceExecutor
 
-__all__ = ["LLMInferenceSagemakerEndpoint", "InferenceExecutor"]
+__all__ = ["InferenceExecutor", "LLMInferenceSagemakerEndpoint"]

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -5,13 +5,15 @@ from .export_artifact_to_json import export_artifact_to_json
 from .feature_engineering import feature_engineering
 from .generate_datasets import generate_datasets
 from .training import training
+from .velog_data_etl import velog_data_etl
 
 __all__ = [
-    "generate_datasets",
+    "digital_data_etl",
     "end_to_end_data",
     "evaluating",
     "export_artifact_to_json",
-    "digital_data_etl",
     "feature_engineering",
+    "generate_datasets",
     "training",
+    "velog_data_etl",
 ]

--- a/pipelines/velog_data_etl.py
+++ b/pipelines/velog_data_etl.py
@@ -1,0 +1,21 @@
+from zenml import pipeline
+
+from steps.etl import fetch_velog_posts, get_or_create_user
+
+
+@pipeline
+def velog_data_etl(
+    user_full_name: str,
+    velog_username: str,
+    access_token: str,
+    refresh_token: str,
+) -> str:
+    user = get_or_create_user(user_full_name)
+    last_step = fetch_velog_posts(
+        user=user,
+        velog_username=velog_username,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+    return last_step.invocation_id

--- a/steps/__init__.py
+++ b/steps/__init__.py
@@ -1,3 +1,3 @@
 from . import etl, evaluating, export, feature_engineering, generate_datasets, training
 
-__all__ = ["generate_datasets", "export", "etl", "feature_engineering", "training", "evaluating"]
+__all__ = ["etl", "evaluating", "export", "feature_engineering", "generate_datasets", "training"]

--- a/steps/etl/__init__.py
+++ b/steps/etl/__init__.py
@@ -1,4 +1,5 @@
 from .crawl_links import crawl_links
+from .fetch_velog_posts import fetch_velog_posts
 from .get_or_create_user import get_or_create_user
 
-__all__ = ["crawl_links", "get_or_create_user"]
+__all__ = ["crawl_links", "fetch_velog_posts", "get_or_create_user"]

--- a/steps/etl/fetch_velog_posts.py
+++ b/steps/etl/fetch_velog_posts.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from loguru import logger
+from typing_extensions import Annotated
+from zenml import get_step_context, step
+
+from llm_engineering.application.velog import VelogService
+from llm_engineering.domain.documents import PostDocument, UserDocument
+
+
+@step
+def fetch_velog_posts(
+    user: Annotated[UserDocument, "user"],
+    velog_username: str,
+    access_token: str,
+    refresh_token: str,
+) -> Annotated[list[str], "post_ids"]:
+    logger.info(f"Fetching Velog posts for {velog_username}")
+    service = VelogService(access_token=access_token, refresh_token=refresh_token)
+    posts = service.get_all_posts(velog_username)
+    post_ids: list[str] = []
+    for post in posts:
+        doc = PostDocument(
+            content={
+                "title": post.get("title", ""),
+                "short_description": post.get("short_description", ""),
+                "body": post.get("body", ""),
+            },
+            image=post.get("thumbnail"),
+            link=f"https://velog.io/@{velog_username}/{post.get('url_slug')}",
+            platform="velog",
+            author_id=user.id,
+            author_full_name=user.full_name,
+        )
+        saved = doc.save()
+        if saved:
+            post_ids.append(str(doc.id))
+
+    step_context = get_step_context()
+    step_context.add_output_metadata(
+        output_name="post_ids", metadata={"num_posts": len(post_ids)}
+    )
+    return post_ids

--- a/steps/export/__init__.py
+++ b/steps/export/__init__.py
@@ -1,4 +1,4 @@
 from .serialize_artifact import serialize_artifact
 from .to_json import to_json
 
-__all__ = ["to_json", "serialize_artifact"]
+__all__ = ["serialize_artifact", "to_json"]

--- a/steps/feature_engineering/__init__.py
+++ b/steps/feature_engineering/__init__.py
@@ -4,8 +4,8 @@ from .query_data_warehouse import query_data_warehouse
 from .rag import chunk_and_embed
 
 __all__ = [
+    "chunk_and_embed",
     "clean_documents",
     "load_to_vector_db",
     "query_data_warehouse",
-    "chunk_and_embed",
 ]

--- a/steps/generate_datasets/__init__.py
+++ b/steps/generate_datasets/__init__.py
@@ -5,9 +5,9 @@ from .push_to_huggingface import push_to_huggingface
 from .query_feature_store import query_feature_store
 
 __all__ = [
+    "create_prompts",
     "generate_intruction_dataset",
     "generate_preference_dataset",
-    "create_prompts",
     "push_to_huggingface",
     "query_feature_store",
 ]


### PR DESCRIPTION
## Summary
- implement a Velog client and constants
- add a step to fetch Velog posts
- create `velog_data_etl` pipeline
- expose the new pipeline through `pipelines` package
- minor fixes from linting, including small update in GitHub crawler

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e3be4590832ca6660b239c7bad84